### PR TITLE
add support for loongarch64

### DIFF
--- a/neofetch
+++ b/neofetch
@@ -2208,8 +2208,8 @@ get_cpu() {
 
                 *)
                     cpu="$(awk -F '\\s*: | @' \
-                            '/model name|Hardware|Processor|^cpu model|chip type|^cpu type/ {
-                            cpu=$2; if ($1 == "Hardware") exit } END { print cpu }' "$cpu_file")"
+                            '/[mM]odel [nN]ame|Hardware|Processor|^cpu model|chip type|^cpu type/ {
+                            cpu=$2; if ($1 == "Hardware" || $1 == "Model Name") exit } END { print cpu }' "$cpu_file")"
                 ;;
             esac
 


### PR DESCRIPTION
## Description

在 3A5000 机器上，修复 neofetch 显示 cpu 信息不正确的问题。
```
$ uname -m
loongarch64
$ cat /proc/cpuinfo 
system type		: generic-loongson-machine

processor		: 0
package			: 0
core			: 0
CPU Family		: Loongson-64bit
Model Name		: Loongson-3A5000
CPU Revision		: 0x10
FPU Revision		: 0x00
CPU MHz			: 1600.00
BogoMIPS		: 3200.00
TLB Entries		: 2112
Address Sizes		: 48 bits physical, 48 bits virtual
ISA			: loongarch32 loongarch64
Features		: cpucfg lam ual fpu lsx lasx complex crypto lvz
Hardware Watchpoint	: yes, iwatch count: 8, dwatch count: 8

processor		: 1
package			: 0
core			: 1
CPU Family		: Loongson-64bit
Model Name		: Loongson-3A5000
CPU Revision		: 0x10
FPU Revision		: 0x00
CPU MHz			: 1600.00
BogoMIPS		: 3200.00
TLB Entries		: 2112
Address Sizes		: 48 bits physical, 48 bits virtual
ISA			: loongarch32 loongarch64
Features		: cpucfg lam ual fpu lsx lasx complex crypto lvz
Hardware Watchpoint	: yes, iwatch count: 8, dwatch count: 8

processor		: 2
package			: 0
core			: 2
CPU Family		: Loongson-64bit
Model Name		: Loongson-3A5000
CPU Revision		: 0x10
FPU Revision		: 0x00
CPU MHz			: 1600.00
BogoMIPS		: 3200.00
TLB Entries		: 2112
Address Sizes		: 48 bits physical, 48 bits virtual
ISA			: loongarch32 loongarch64
Features		: cpucfg lam ual fpu lsx lasx complex crypto lvz
Hardware Watchpoint	: yes, iwatch count: 8, dwatch count: 8

processor		: 3
package			: 0
core			: 3
CPU Family		: Loongson-64bit
Model Name		: Loongson-3A5000
CPU Revision		: 0x10
FPU Revision		: 0x00
CPU MHz			: 1600.00
BogoMIPS		: 3200.00
TLB Entries		: 2112
Address Sizes		: 48 bits physical, 48 bits virtual
ISA			: loongarch32 loongarch64
Features		: cpucfg lam ual fpu lsx lasx complex crypto lvz
Hardware Watchpoint	: yes, iwatch count: 8, dwatch count: 8
```

应用补丁前：
```
CPU: yes, iwatch count (4)
```
应用补丁后:
```
CPU: Loongson-3A5000 (4)
```